### PR TITLE
[WIP] 2.12 support, MonadErrorTests broken

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 organization in ThisBuild := "org.julienrf"
 
 scalaVersion in ThisBuild := "2.12.1"
+crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 scalacOptions in ThisBuild ++= Seq(
   "-feature",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization in ThisBuild := "org.julienrf"
 
-scalaVersion in ThisBuild := "2.11.8"
+scalaVersion in ThisBuild := "2.12.1"
 
 scalacOptions in ThisBuild ++= Seq(
   "-feature",
@@ -53,17 +53,17 @@ val `faithful-cats` =
     .settings(publishSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "org.typelevel" %%% "cats" % "0.7.0",
-        "org.typelevel"  %%% "cats-laws" % "0.7.0" % Test,
-        "org.typelevel" %%% "discipline" % "0.5" % Test,
-        "org.scalatest" %%% "scalatest" % "3.0.0-M15" % Test
+        "org.typelevel" %%% "cats" % "0.8.1",
+        "org.typelevel"  %%% "cats-laws" % "0.8.1" % Test,
+        "org.typelevel" %%% "discipline" % "0.7.3" % Test,
+        "org.scalatest" %%% "scalatest" % "3.0.1" % Test
       )
     )
     .dependsOn(faithful)
 
 val benchmarkDeps = Def.setting {
   Seq(
-    "org.scala-js" %%% "scalajs-dom" % "0.9.0"
+    "org.scala-js" %%% "scalajs-dom" % "0.9.1"
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.8")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 


### PR DESCRIPTION
Hi,

I tried to add support for Scala 2.12 but it was harder that I thought. Following errors came up:
1. MonadErrorTests has broken, running it effects in "Maximum call stack size exceeded"
2. My implementation of scalacheck Cogen may be wrong, I have very little experience with it and I just followed method signatures

I don't have enough knowledge to pursuit  it further but maybe someone would like to take it from here.