### PR TITLE
Bump all dependencies (and sbt) to latest revisions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization in ThisBuild := "org.julienrf"
 
-scalaVersion in ThisBuild := "2.12.1"
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+scalaVersion in ThisBuild := "2.12.4"
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 scalacOptions in ThisBuild ++= Seq(
   "-feature",
@@ -60,17 +60,17 @@ val `faithful-cats` =
     .settings(publishSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "org.typelevel" %%% "cats" % "0.9.0",
-        "org.typelevel"  %%% "cats-laws" % "0.9.0" % Test,
-        "org.typelevel" %%% "discipline" % "0.7.3" % Test,
-        "org.scalatest" %%% "scalatest" % "3.0.1" % Test
+        "org.typelevel" %%% "cats-core" % "1.1.0",
+        "org.typelevel"  %%% "cats-laws" % "1.1.0" % Test,
+        "org.typelevel" %%% "discipline" % "0.8" % Test,
+        "org.scalatest" %%% "scalatest" % "3.0.4" % Test
       )
     )
     .dependsOn(faithful)
 
 val benchmarkDeps = Def.setting {
   Seq(
-    "org.scala-js" %%% "scalajs-dom" % "0.9.1"
+    "org.scala-js" %%% "scalajs-dom" % "0.9.5"
   )
 }
 

--- a/faithful-cats/src/test/scala/faithful/cats/AsyncTestSuite.scala
+++ b/faithful-cats/src/test/scala/faithful/cats/AsyncTestSuite.scala
@@ -14,14 +14,14 @@ class AsyncTestSuite extends AsyncFunSuite {
     val y = x.future.map(_ + 1)
     x.success(42)
     val z = x.future.map(_ * 2)
-    val assertion = (y |@| z).map((xx, yy) => assert(xx == 43 && yy == 84))
+    val assertion = (y, z).mapN((xx, yy) => assert(xx == 43 && yy == 84))
     asScalaFuture(assertion)
   }
 
   test("no exception catching") {
     class MyException extends Exception
     val x = new Promise[Int]()
-    val y = x.future.map[Int](_ => throw new MyException)
+    x.future.map[Int](_ => throw new MyException)
     intercept[MyException] {
       x.success(42)
     }

--- a/faithful-cats/src/test/scala/faithful/cats/TestSuite.scala
+++ b/faithful-cats/src/test/scala/faithful/cats/TestSuite.scala
@@ -7,8 +7,8 @@ import cats.instances.int._
 import cats.instances.option.catsKernelStdEqForOption
 import cats.instances.string._
 import cats.instances.unit._
-import cats.laws.discipline.CartesianTests.Isomorphisms
 import cats.laws.discipline.MonadErrorTests
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import faithful.{Future, Promise}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
@@ -65,7 +65,7 @@ object ArbitraryFuture {
 
 object EqFuture {
 
-  implicit val eqThrowable: Eq[Throwable] = Eq[String].on(_.toString)
+  implicit val eqThrowable: Eq[Throwable] = Eq.by[Throwable, String](_.toString)
 
   implicit def eqFuture[A](implicit eqA: Eq[Option[Either[Throwable, A]]]): Eq[Future[A]] =
     (fa1: Future[A], fa2: Future[A]) => eqA.eqv(Future.completion(fa1), Future.completion(fa2))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")


### PR DESCRIPTION
My goal here is to get a copy of endpoints that is cats 1.0+ compatible. Hopefully these changes pass muster and didn't break sbt-release, those are tough for me to test.